### PR TITLE
chore: improve dockerfile for security and performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+#
 # Dockerfile
 # Multi-architecture build supporting AMD64 and ARM64
 # Uses QEMU emulation for cross-platform builds with CGO
@@ -7,26 +9,24 @@
 # CGO requires native compilation, QEMU will emulate the target platform
 FROM golang:1.24-bookworm AS builder
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    gcc \
-    g++ \
-    make \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
 
-WORKDIR /app
-
-# Copy go mod files
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy source code
-COPY . .
+RUN --mount=type=bind,source=go.mod,target=go.mod,ro \
+    --mount=type=bind,source=go.sum,target=go.sum,ro \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Build the application with CGO for DuckDB
 # Native build on each platform (emulated via QEMU for cross-platform)
-RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o snowflake-emulator ./cmd/server
+RUN --mount=type=bind,source=.,target=/src,ro \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 go build \
+      -trimpath \
+      -buildvcs=false \
+      -ldflags="-s -w" \
+      -o /snowflake-emulator \
+      ./cmd/server
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim
@@ -38,29 +38,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN useradd -r -u 1001 -g root snowflake
+RUN useradd -u 10001 -g root -d /nonexistent -s /usr/sbin/nologin --no-create-home snowflake
 
 WORKDIR /app
 
-# Copy binary from builder
-COPY --from=builder /app/snowflake-emulator .
+COPY --from=builder /snowflake-emulator .
 
-# Create directories for persistent data and stages
-RUN mkdir -p /data/stages && chown -R snowflake:root /app /data
+RUN mkdir -p /data/stages \
+    && chown -R snowflake:root /app /data
 
 USER snowflake
 
-# Environment variables with defaults
-ENV PORT=8080
-ENV DB_PATH=":memory:"
-ENV STAGE_DIR="/data/stages"
+ENV PORT=8080 \
+    DB_PATH=":memory:" \
+    STAGE_DIR="/data/stages"
 
-# Expose default port
 EXPOSE 8080
 
-# Health check endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${PORT}/health || exit 1
 
-# Run the application
 ENTRYPOINT ["./snowflake-emulator"]


### PR DESCRIPTION
- Refactored the Dockerfile to follow Docker best practices and reduce COPY usage, removing COPY . . in the builder stage.
- Switched the build to BuildKit bind mounts for source (--mount=type=bind) and cache mounts for Go modules/build cache (--mount=type=cache) to improve CI caching and keep builder layers small.
- Kept the runtime image slim and secure: non-root user, minimal packages, and existing /health HEALTHCHECK behavior preserved.