### PR TITLE
fix: apply gosnowflake bindings in query protocol handler

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,6 +66,7 @@ func main() {
 	copyProcessor := query.NewCopyProcessor(stageMgr, repo, executor)
 	mergeProcessor := query.NewMergeProcessor(executor)
 	executor.Configure(
+		query.WithStageManager(stageMgr),
 		query.WithCopyProcessor(copyProcessor),
 		query.WithMergeProcessor(mergeProcessor),
 	)

--- a/pkg/query/classifier.go
+++ b/pkg/query/classifier.go
@@ -231,3 +231,23 @@ func IsRollback(sql string) bool {
 	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
 	return strings.HasPrefix(upperSQL, "ROLLBACK")
 }
+
+func (c *Classifier) IsCreateStage(sql string) bool {
+	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
+	return strings.HasPrefix(upperSQL, "CREATE STAGE") ||
+		strings.HasPrefix(upperSQL, "CREATE OR REPLACE STAGE") ||
+		strings.HasPrefix(upperSQL, "CREATE STAGE IF NOT EXISTS")
+}
+
+func (c *Classifier) IsPut(sql string) bool {
+	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
+	return strings.HasPrefix(upperSQL, "PUT ")
+}
+
+func IsCreateStage(sql string) bool {
+	return DefaultClassifier.IsCreateStage(sql)
+}
+
+func IsPut(sql string) bool {
+	return DefaultClassifier.IsPut(sql)
+}

--- a/pkg/query/copy_processor.go
+++ b/pkg/query/copy_processor.go
@@ -2,6 +2,7 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -17,18 +18,20 @@ import (
 
 // CopyStatement represents a parsed COPY INTO statement.
 type CopyStatement struct {
-	TargetTable    string
-	TargetDatabase string
-	TargetSchema   string
-	StageName      string
-	StageSchemaID  string
-	StagePath      string
-	FileFormat     FileFormatOptions
-	Files          []string // Specific files to load
-	Pattern        string   // File pattern
-	OnError        string   // CONTINUE, SKIP_FILE, ABORT
-	PurgeFiles     bool     // Whether to purge files after loading
-	ValidationMode bool     // Whether to validate only
+	TargetTable       string
+	TargetDatabase    string
+	TargetSchema      string
+	TargetColumns     []string
+	SelectExpressions []string
+	StageName         string
+	StageSchemaID     string
+	StagePath         string
+	FileFormat        FileFormatOptions
+	Files             []string // Specific files to load
+	Pattern           string   // File pattern
+	OnError           string   // CONTINUE, SKIP_FILE, ABORT
+	PurgeFiles        bool     // Whether to purge files after loading
+	ValidationMode    bool     // Whether to validate only
 }
 
 // FileFormatOptions contains file format settings for COPY.
@@ -49,6 +52,7 @@ type FileFormatOptions struct {
 // Stored in CopyProcessor to avoid global state and enable heap allocation.
 type copyPatterns struct {
 	copyInto        *regexp.Regexp
+	copyIntoSelect  *regexp.Regexp
 	fileFormat      *regexp.Regexp
 	pattern         *regexp.Regexp
 	onError         *regexp.Regexp
@@ -61,7 +65,10 @@ type copyPatterns struct {
 // newCopyPatterns creates pre-compiled regex patterns.
 func newCopyPatterns() *copyPatterns {
 	return &copyPatterns{
-		copyInto:        regexp.MustCompile(`(?i)COPY\s+INTO\s+([^\s(]+)\s+FROM\s+@([^\s/]+)(/\S*)?`),
+		copyInto: regexp.MustCompile(`(?i)COPY\s+INTO\s+([^\s(]+)\s+FROM\s+@([^\s/]+)(/\S*)?`),
+
+		copyIntoSelect: regexp.MustCompile(`(?is)^COPY\s+INTO\s+([^\s(]+)\s*(?:\((.*?)\))?\s+FROM\s*\(\s*SELECT\s+(.*?)\s+FROM\s+(@[^\s)]+)\s*\)\s*FILE_FORMAT\s*=\s*\(([^)]*)\)\s*$`),
+
 		fileFormat:      regexp.MustCompile(`(?i)FILE_FORMAT\s*=\s*\(([^)]+)\)`),
 		pattern:         regexp.MustCompile(`(?i)PATTERN\s*=\s*'([^']+)'`),
 		onError:         regexp.MustCompile(`(?i)ON_ERROR\s*=\s*(\w+)`),
@@ -109,6 +116,10 @@ func NewCopyProcessor(stageMgr *stage.Manager, repo *metadata.Repository, execut
 // ParseCopyStatement parses a COPY INTO SQL statement.
 func (h *CopyProcessor) ParseCopyStatement(sql string) (*CopyStatement, error) {
 	sql = strings.TrimSpace(sql)
+
+	if stmt, err := h.parseCopyIntoSelect(sql); err == nil {
+		return stmt, nil
+	}
 
 	// Match COPY INTO table FROM @stage[/path]
 	matches := h.patterns.copyInto.FindStringSubmatch(sql)
@@ -334,7 +345,7 @@ func (h *CopyProcessor) loadCSVFile(ctx context.Context, stmt *CopyStatement, sc
 	}
 
 	// Build INSERT statement using centralized table naming
-	tableName := h.tableNamer.BuildDuckDBTableName(stmt.TargetDatabase, stmt.TargetSchema, stmt.TargetTable)
+	tableName := buildDuckDBQualifiedTableName(stmt.TargetSchema, stmt.TargetTable)
 
 	var rowsInserted int64
 	for _, record := range records {
@@ -388,32 +399,9 @@ func (h *CopyProcessor) loadJSONFile(ctx context.Context, stmt *CopyStatement, s
 		return 0, fmt.Errorf("failed to read JSON file: %w", err)
 	}
 
-	// Parse JSON
-	var data interface{}
-	if err := json.Unmarshal(content, &data); err != nil {
-		return 0, fmt.Errorf("failed to parse JSON: %w", err)
-	}
-
-	// Handle array of objects
-	var records []map[string]interface{}
-	switch v := data.(type) {
-	case []interface{}:
-		if stmt.FileFormat.StripOuterArray {
-			for _, item := range v {
-				if obj, ok := item.(map[string]interface{}); ok {
-					records = append(records, obj)
-				}
-			}
-		} else {
-			// Each array element as a single VARIANT column
-			for _, item := range v {
-				records = append(records, map[string]interface{}{"$1": item})
-			}
-		}
-	case map[string]interface{}:
-		records = append(records, v)
-	default:
-		return 0, fmt.Errorf("unsupported JSON structure")
+	records, err := parseJSONRecords(content, stmt.FileFormat.StripOuterArray)
+	if err != nil {
+		return 0, err
 	}
 
 	if len(records) == 0 {
@@ -421,25 +409,304 @@ func (h *CopyProcessor) loadJSONFile(ctx context.Context, stmt *CopyStatement, s
 	}
 
 	// Build table name using centralized table naming
-	tableName := h.tableNamer.BuildDuckDBTableName(stmt.TargetDatabase, stmt.TargetSchema, stmt.TargetTable)
+	tableName := buildDuckDBQualifiedTableName(stmt.TargetSchema, stmt.TargetTable)
 
 	var rowsInserted int64
 	for _, record := range records {
-		// Convert record to JSON string for VARIANT column
-		jsonBytes, err := json.Marshal(record)
-		if err != nil {
-			return rowsInserted, fmt.Errorf("failed to serialize record: %w", err)
+		values := make([]string, 0)
+
+		if len(stmt.TargetColumns) > 0 && len(stmt.SelectExpressions) > 0 {
+			for _, expr := range stmt.SelectExpressions {
+				valueSQL, err := jsonSelectExpressionToSQLValue(expr, record)
+				if err != nil {
+					return rowsInserted, err
+				}
+
+				values = append(values, valueSQL)
+			}
+		} else {
+			jsonBytes, err := json.Marshal(record)
+			if err != nil {
+				return rowsInserted, fmt.Errorf("failed to serialize record: %w", err)
+			}
+
+			values = append(values, "'"+strings.ReplaceAll(string(jsonBytes), "'", "''")+"'")
 		}
 
-		// Insert as JSON/VARIANT
-		insertSQL := fmt.Sprintf("INSERT INTO %s VALUES ('%s')", tableName, strings.ReplaceAll(string(jsonBytes), "'", "''"))
+		insertSQL := fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES (%s)",
+			tableName,
+			strings.Join(quoteColumnNames(stmt.TargetColumns), ", "),
+			strings.Join(values, ", "),
+		)
 
 		_, err = h.executor.executeRaw(ctx, insertSQL)
 		if err != nil {
 			return rowsInserted, fmt.Errorf("failed to insert JSON row: %w", err)
 		}
+
 		rowsInserted++
 	}
 
 	return rowsInserted, nil
+}
+
+func (h *CopyProcessor) parseCopyIntoSelect(sql string) (*CopyStatement, error) {
+	matches := h.patterns.copyIntoSelect.FindStringSubmatch(sql)
+	if len(matches) < 6 {
+		return nil, fmt.Errorf("invalid COPY INTO SELECT syntax")
+	}
+
+	targetTableRef := strings.TrimSpace(matches[1])
+	targetColumnsText := strings.TrimSpace(matches[2])
+	selectExpressionsText := strings.TrimSpace(matches[3])
+	stageLocation := strings.TrimSpace(matches[4])
+	fileFormatText := strings.TrimSpace(matches[5])
+
+	stmt := &CopyStatement{
+		FileFormat: FileFormatOptions{
+			Type:            "CSV",
+			FieldDelimiter:  ",",
+			RecordDelimiter: "\n",
+			SkipHeader:      0,
+		},
+		OnError: "ABORT",
+	}
+
+	// Target table
+	targetDatabase, targetSchema, targetTable := splitQualifiedObjectName(targetTableRef)
+	stmt.TargetDatabase = targetDatabase
+	stmt.TargetSchema = targetSchema
+	stmt.TargetTable = targetTable
+
+	// Target columns
+	if targetColumnsText != "" {
+		stmt.TargetColumns = cleanIdentList(splitCommaList(targetColumnsText))
+	}
+
+	// SELECT expressions
+	if selectExpressionsText != "" {
+		stmt.SelectExpressions = splitCommaList(selectExpressionsText)
+	}
+
+	// Stage location
+	stageObject, stagePath := splitStageRef(stageLocation)
+	_, _, stageName := splitQualifiedObjectName(stageObject)
+
+	stmt.StageName = stageName
+	stmt.StagePath = stagePath
+
+	h.parseFileFormatOptions(&stmt.FileFormat, fileFormatText)
+
+	return stmt, nil
+}
+
+func splitCommaList(input string) []string {
+	var result []string
+	var current strings.Builder
+
+	depth := 0
+	inSingleQuote := false
+	inDoubleQuote := false
+
+	for _, r := range input {
+		switch r {
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			}
+			current.WriteRune(r)
+
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			}
+			current.WriteRune(r)
+
+		case '(':
+			if !inSingleQuote && !inDoubleQuote {
+				depth++
+			}
+			current.WriteRune(r)
+
+		case ')':
+			if !inSingleQuote && !inDoubleQuote && depth > 0 {
+				depth--
+			}
+			current.WriteRune(r)
+
+		case ',':
+			if !inSingleQuote && !inDoubleQuote && depth == 0 {
+				value := strings.TrimSpace(current.String())
+				if value != "" {
+					result = append(result, value)
+				}
+				current.Reset()
+			} else {
+				current.WriteRune(r)
+			}
+
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	value := strings.TrimSpace(current.String())
+	if value != "" {
+		result = append(result, value)
+	}
+
+	return result
+}
+
+func cleanIdentList(values []string) []string {
+	result := make([]string, 0, len(values))
+
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"`)
+		value = strings.ToUpper(value)
+
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+
+	return result
+}
+
+func jsonSelectExpressionToSQLValue(expr string, record map[string]interface{}) (string, error) {
+	expr = strings.TrimSpace(expr)
+
+	if strings.EqualFold(expr, "CURRENT_TIMESTAMP()") {
+		return "CURRENT_TIMESTAMP", nil
+	}
+
+	re := regexp.MustCompile(`(?i)^\$1\s*:\s*"([^"]+)"$`)
+	matches := re.FindStringSubmatch(expr)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("unsupported JSON select expression: %s", expr)
+	}
+
+	fieldName := matches[1]
+
+	value, exists := record[fieldName]
+	if !exists {
+		return ValueNull, nil
+	}
+
+	return jsonValueToSQLLiteral(value), nil
+}
+
+func jsonValueToSQLLiteral(value interface{}) string {
+	if value == nil {
+		return ValueNull
+	}
+
+	switch v := value.(type) {
+	case string:
+		return "'" + strings.ReplaceAll(v, "'", "''") + "'"
+
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+
+	case bool:
+		if v {
+			return "TRUE"
+		}
+		return "FALSE"
+
+	default:
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return ValueNull
+		}
+
+		return "'" + strings.ReplaceAll(string(jsonBytes), "'", "''") + "'"
+	}
+}
+
+func parseJSONRecords(content []byte, stripOuterArray bool) ([]map[string]interface{}, error) {
+	content = bytes.TrimSpace(content)
+	if len(content) == 0 {
+		return nil, nil
+	}
+
+	var records []map[string]interface{}
+
+	// First try normal JSON: object or array.
+	var data interface{}
+	if err := json.Unmarshal(content, &data); err == nil {
+		switch v := data.(type) {
+		case []interface{}:
+			if stripOuterArray {
+				for _, item := range v {
+					if obj, ok := item.(map[string]interface{}); ok {
+						records = append(records, obj)
+					}
+				}
+			} else {
+				for _, item := range v {
+					records = append(records, map[string]interface{}{"$1": item})
+				}
+			}
+
+		case map[string]interface{}:
+			records = append(records, v)
+
+		default:
+			return nil, fmt.Errorf("unsupported JSON structure")
+		}
+
+		return records, nil
+	}
+
+	// Fallback: NDJSON / JSON Lines.
+	lines := bytes.Split(content, []byte("\n"))
+
+	for lineNumber, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var record map[string]interface{}
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON line %d: %w", lineNumber+1, err)
+		}
+
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+func buildDuckDBQualifiedTableName(schemaName string, tableName string) string {
+	schemaName = normalizeSnowflakeIdent(schemaName)
+	tableName = normalizeSnowflakeIdent(tableName)
+
+	if schemaName == "" {
+		return quoteDuckDBIdent(tableName)
+	}
+
+	return quoteDuckDBIdent(schemaName) + "." + quoteDuckDBIdent(tableName)
+}
+
+func quoteColumnNames(columns []string) []string {
+	quoted := make([]string, 0, len(columns))
+
+	for _, col := range columns {
+		col = strings.TrimSpace(col)
+		col = strings.Trim(col, `"`)
+		if col == "" {
+			continue
+		}
+
+		quoted = append(quoted, quoteDuckDBIdent(strings.ToUpper(col)))
+	}
+
+	return quoted
 }

--- a/pkg/query/execution_context.go
+++ b/pkg/query/execution_context.go
@@ -1,0 +1,7 @@
+package query
+
+type ExecutionContext struct {
+	SessionID     string
+	Database      string
+	CurrentSchema string
+}

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -1,9 +1,14 @@
 package query
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -12,6 +17,7 @@ import (
 
 	"github.com/nnnkkk7/snowflake-emulator/pkg/connection"
 	"github.com/nnnkkk7/snowflake-emulator/pkg/metadata"
+	"github.com/nnnkkk7/snowflake-emulator/pkg/stage"
 )
 
 // Binding validation regexes to prevent SQL injection
@@ -31,6 +37,51 @@ type Executor struct {
 	translator     *Translator
 	copyProcessor  *CopyProcessor
 	mergeProcessor *MergeProcessor
+	stageMgr       *stage.Manager
+}
+
+type createStageStatement struct {
+	Database    string
+	Schema      string
+	Name        string
+	IfNotExists bool
+}
+
+type putStatement struct {
+	LocalPath    string
+	Database     string
+	Schema       string
+	StageName    string
+	StagePath    string
+	AutoCompress bool
+	Overwrite    bool
+}
+
+type removeStatement struct {
+	Database  string
+	Schema    string
+	StageName string
+	StagePath string
+	Pattern   string
+}
+
+type listStatement struct {
+	Database  string
+	Schema    string
+	StageName string
+	StagePath string
+	Pattern   string
+}
+
+type PutFileTransferPlan struct {
+	LocalPath           string
+	Database            string
+	Schema              string
+	StageName           string
+	StagePath           string
+	StageLocalDirectory string
+	AutoCompress        bool
+	Overwrite           bool
 }
 
 // ExecutorOption configures an Executor.
@@ -47,6 +98,12 @@ func WithCopyProcessor(processor *CopyProcessor) ExecutorOption {
 func WithMergeProcessor(processor *MergeProcessor) ExecutorOption {
 	return func(e *Executor) {
 		e.mergeProcessor = processor
+	}
+}
+
+func WithStageManager(manager *stage.Manager) ExecutorOption {
+	return func(e *Executor) {
+		e.stageMgr = manager
 	}
 }
 
@@ -73,6 +130,10 @@ func (e *Executor) Configure(opts ...ExecutorOption) {
 
 // Query executes a SELECT query and returns results.
 func (e *Executor) Query(ctx context.Context, sql string) (*Result, error) {
+	if isListStatement(sql) {
+		return e.QueryList(ctx, ExecutionContext{}, sql)
+	}
+
 	// Translate Snowflake SQL to DuckDB SQL
 	translatedSQL, err := e.translator.Translate(sql)
 	if err != nil {
@@ -143,6 +204,18 @@ func (e *Executor) QueryWithBindings(ctx context.Context, sql string, bindings m
 	}
 
 	return e.Query(ctx, boundSQL)
+}
+
+func (e *Executor) QueryWithContext(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*Result, error) {
+	if isListStatement(sqlText) {
+		return e.QueryList(ctx, execCtx, sqlText)
+	}
+
+	return e.Query(ctx, sqlText)
 }
 
 // applyBindings replaces :N placeholders with actual values from bindings.
@@ -334,51 +407,135 @@ func (e *Executor) ExecuteWithBindings(ctx context.Context, sql string, bindings
 	return e.Execute(ctx, boundSQL)
 }
 
-// Execute executes a non-query SQL statement (INSERT, UPDATE, DELETE, CREATE, DROP, etc.).
-func (e *Executor) Execute(ctx context.Context, sql string) (*ExecResult, error) {
-	// Use classifier to detect DDL statements that need metadata tracking
-	classifier := NewClassifier()
-
-	// For CREATE TABLE, we need to register it in metadata
-	if classifier.IsCreateTable(sql) {
-		return e.executeCreateTable(ctx, sql)
+func (e *Executor) ExecuteWithBindingsAndContext(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+	bindings map[string]*QueryBindingValue,
+) (*ExecResult, error) {
+	if len(bindings) == 0 {
+		return e.ExecuteWithContext(ctx, execCtx, sqlText)
 	}
 
-	// For DROP TABLE, we need to remove it from metadata
-	if classifier.IsDropTable(sql) {
-		return e.executeDropTable(ctx, sql)
+	boundSQL, err := e.applyBindings(sqlText, bindings)
+	if err != nil {
+		return nil, fmt.Errorf("binding error: %w", err)
+	}
+
+	return e.ExecuteWithContext(ctx, execCtx, boundSQL)
+}
+
+// Execute executes a non-query SQL statement (INSERT, UPDATE, DELETE, CREATE, DROP, etc.).
+func (e *Executor) Execute(ctx context.Context, sqlText string) (*ExecResult, error) {
+	return e.ExecuteWithContext(ctx, ExecutionContext{}, sqlText)
+}
+
+func (e *Executor) ExecuteWithContext(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*ExecResult, error) {
+	classifier := NewClassifier()
+	log.Printf("ExecuteWithContext sql=%q", sqlText)
+
+	// For CREATE STAGE, we need to register it in metadata
+	if classifier.IsCreateStage(sqlText) {
+		return e.executeCreateStage(ctx, execCtx, sqlText)
+	}
+
+	// For PUT, we need to upload a local file into an internal stage
+	if classifier.IsPut(sqlText) {
+		log.Printf("ExecuteWithContext detected PUT")
+		return e.executePut(ctx, execCtx, sqlText)
+	}
+
+	if isRemoveStatement(sqlText) {
+		return e.executeRemove(ctx, execCtx, sqlText)
+	}
+
+	if isListStatement(sqlText) {
+		return e.executeList(ctx, execCtx, sqlText)
+	}
+
+	// For CREATE TABLE, we need to register it in metadata
+	if classifier.IsCreateTable(sqlText) {
+		return e.executeCreateTable(ctx, execCtx, sqlText)
+	}
+
+	if classifier.IsDropTable(sqlText) {
+		return e.executeDropTable(ctx, execCtx, sqlText)
 	}
 
 	// Handle transaction control statements
-	if IsTransaction(sql) {
-		return e.executeTransaction(ctx, sql)
+	if IsTransaction(sqlText) {
+		return e.executeTransaction(ctx, sqlText)
 	}
 
 	// Handle COPY INTO statements
-	if IsCopy(sql) {
-		return e.executeCopy(ctx, sql)
+	if IsCopy(sqlText) {
+		return e.executeCopy(ctx, execCtx, sqlText)
 	}
 
 	// Handle MERGE INTO statements
-	if IsMerge(sql) {
-		return e.executeMerge(ctx, sql)
+	if IsMerge(sqlText) {
+		return e.executeMerge(ctx, execCtx, sqlText)
+	}
+
+	// Qualify unqualified DELETE statements using the current schema.
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(sqlText)), "DELETE FROM ") {
+		sqlText = qualifyDeleteWithSchema(sqlText, execCtx.CurrentSchema)
 	}
 
 	// Execute regular SQL statement
-	return e.executeRaw(ctx, sql)
+	return e.executeRawWithContext(ctx, execCtx, sqlText)
+}
+
+func (e *Executor) ExecuteWithHistoryAndContext(ctx context.Context, execCtx ExecutionContext, queryID string, sqlText string) (*ExecResult, error) {
+	startTime := time.Now()
+
+	// Record query start (non-blocking on failure)
+	entry, err := e.repo.RecordQueryStart(ctx, execCtx.SessionID, queryID, sqlText)
+	if err != nil {
+		log.Printf("Failed to record query start: %v", err)
+	}
+
+	result, execErr := e.ExecuteWithContext(ctx, execCtx, sqlText)
+
+	// Calculate execution time
+	executionTimeMs := time.Since(startTime).Milliseconds()
+
+	// Record result
+	if entry != nil {
+		if execErr != nil {
+			_ = e.repo.RecordQueryFailure(ctx, entry.ID, execErr.Error(), executionTimeMs)
+		} else {
+			var rowsAffected int64
+			if result != nil {
+				rowsAffected = result.RowsAffected
+			}
+
+			_ = e.repo.RecordQuerySuccess(ctx, entry.ID, rowsAffected, executionTimeMs)
+		}
+	}
+
+	return result, execErr
 }
 
 // executeRaw executes a SQL statement without classification or processor delegation.
 // Use this from processors (COPY, MERGE) to avoid infinite recursion.
 // This is a private method as it's only called from same-package processors.
-func (e *Executor) executeRaw(ctx context.Context, sql string) (*ExecResult, error) {
-	// Translate Snowflake SQL to DuckDB SQL
+func (e *Executor) executeRawWithContext(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sql string,
+) (*ExecResult, error) {
+	sql = rewriteTableRefsToPhysicalDuckDB(sql, execCtx.CurrentSchema)
+
 	translatedSQL, err := e.translator.Translate(sql)
 	if err != nil {
 		return nil, fmt.Errorf("translation error: %w", err)
 	}
 
-	// Execute statement
 	result, err := e.mgr.Exec(ctx, translatedSQL)
 	if err != nil {
 		return nil, fmt.Errorf("execution error: %w", err)
@@ -389,14 +546,20 @@ func (e *Executor) executeRaw(ctx context.Context, sql string) (*ExecResult, err
 		return nil, fmt.Errorf("failed to get rows affected: %w", err)
 	}
 
-	return &ExecResult{
-		RowsAffected: rowsAffected,
-	}, nil
+	return &ExecResult{RowsAffected: rowsAffected}, nil
 }
 
-// executeCreateTable handles CREATE TABLE statements with metadata registration.
-func (e *Executor) executeCreateTable(ctx context.Context, sql string) (*ExecResult, error) {
-	// Execute the CREATE TABLE in DuckDB first
+func (e *Executor) executeRaw(ctx context.Context, sql string) (*ExecResult, error) {
+	return e.executeRawWithContext(ctx, ExecutionContext{}, sql)
+}
+
+func (e *Executor) executeCreateTable(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sql string,
+) (*ExecResult, error) {
+	sql = rewriteTableRefsToPhysicalDuckDB(sql, execCtx.CurrentSchema)
+
 	translatedSQL, err := e.translator.Translate(sql)
 	if err != nil {
 		return nil, fmt.Errorf("translation error: %w", err)
@@ -406,18 +569,16 @@ func (e *Executor) executeCreateTable(ctx context.Context, sql string) (*ExecRes
 		return nil, fmt.Errorf("create table execution error: %w", err)
 	}
 
-	// Note: In a full implementation, we would parse the CREATE TABLE statement
-	// and register it in metadata. For now, we just execute it.
-	// This would require SQL parsing to extract table name, columns, etc.
-
-	return &ExecResult{
-		RowsAffected: 0,
-	}, nil
+	return &ExecResult{RowsAffected: 0}, nil
 }
 
-// executeDropTable handles DROP TABLE statements with metadata cleanup.
-func (e *Executor) executeDropTable(ctx context.Context, sql string) (*ExecResult, error) {
-	// Execute the DROP TABLE in DuckDB first
+func (e *Executor) executeDropTable(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sql string,
+) (*ExecResult, error) {
+	sql = rewriteTableRefsToPhysicalDuckDB(sql, execCtx.CurrentSchema)
+
 	translatedSQL, err := e.translator.Translate(sql)
 	if err != nil {
 		return nil, fmt.Errorf("translation error: %w", err)
@@ -427,12 +588,7 @@ func (e *Executor) executeDropTable(ctx context.Context, sql string) (*ExecResul
 		return nil, fmt.Errorf("drop table execution error: %w", err)
 	}
 
-	// Note: In a full implementation, we would remove the table from metadata.
-	// This would require SQL parsing to extract the table name.
-
-	return &ExecResult{
-		RowsAffected: 0,
-	}, nil
+	return &ExecResult{RowsAffected: 0}, nil
 }
 
 // executeTransaction handles transaction control statements (BEGIN, COMMIT, ROLLBACK).
@@ -465,34 +621,39 @@ func (e *Executor) executeTransaction(ctx context.Context, sql string) (*ExecRes
 }
 
 // executeCopy handles COPY INTO statements.
-func (e *Executor) executeCopy(ctx context.Context, sql string) (*ExecResult, error) {
+func (e *Executor) executeCopy(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sql string,
+) (*ExecResult, error) {
 	if e.copyProcessor == nil {
 		return nil, fmt.Errorf("COPY processor not configured")
 	}
 
-	// Parse the COPY statement
 	stmt, err := e.copyProcessor.ParseCopyStatement(sql)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse COPY statement: %w", err)
 	}
 
-	// Resolve schema ID from target database/schema names if provided
-	var schemaID string
-	if stmt.TargetDatabase != "" && stmt.TargetSchema != "" {
-		// Look up database by name
-		db, err := e.repo.GetDatabaseByName(ctx, stmt.TargetDatabase)
-		if err != nil {
-			return nil, fmt.Errorf("database %s not found: %w", stmt.TargetDatabase, err)
-		}
-		// Look up schema by name
-		schema, err := e.repo.GetSchemaByName(ctx, db.ID, stmt.TargetSchema)
-		if err != nil {
-			return nil, fmt.Errorf("schema %s not found in database %s: %w", stmt.TargetSchema, stmt.TargetDatabase, err)
-		}
-		schemaID = schema.ID
+	// Use target database/schema if present; otherwise use session context.
+	if stmt.TargetDatabase == "" {
+		stmt.TargetDatabase = execCtx.Database
+	}
+	if stmt.TargetSchema == "" {
+		stmt.TargetSchema = execCtx.CurrentSchema
 	}
 
-	// Execute COPY INTO with resolved schema context
+	// Use same context for stage when stage is unqualified.
+	schemaID, err := e.resolveSchemaID(
+		ctx,
+		execCtx,
+		stmt.TargetDatabase,
+		stmt.TargetSchema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve COPY schema context: %w", err)
+	}
+
 	result, err := e.copyProcessor.ExecuteCopyInto(ctx, stmt, schemaID)
 	if err != nil {
 		return nil, fmt.Errorf("COPY INTO failed: %w", err)
@@ -504,18 +665,30 @@ func (e *Executor) executeCopy(ctx context.Context, sql string) (*ExecResult, er
 }
 
 // executeMerge handles MERGE INTO statements.
-func (e *Executor) executeMerge(ctx context.Context, sql string) (*ExecResult, error) {
+func (e *Executor) executeMerge(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sql string,
+) (*ExecResult, error) {
 	if e.mergeProcessor == nil {
 		return nil, fmt.Errorf("MERGE processor not configured")
 	}
 
-	// Parse the MERGE statement
+	log.Printf("executeMerge sql=%s", sql)
+
 	stmt, err := e.mergeProcessor.ParseMergeStatement(sql)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse MERGE statement: %w", err)
 	}
 
-	// Execute MERGE
+	if stmt.TargetDatabase == "" {
+		stmt.TargetDatabase = execCtx.Database
+	}
+
+	if stmt.TargetSchema == "" {
+		stmt.TargetSchema = execCtx.CurrentSchema
+	}
+
 	result, err := e.mergeProcessor.ExecuteMerge(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("MERGE failed: %w", err)
@@ -524,6 +697,98 @@ func (e *Executor) executeMerge(ctx context.Context, sql string) (*ExecResult, e
 	return &ExecResult{
 		RowsAffected: result.RowsInserted + result.RowsUpdated + result.RowsDeleted,
 	}, nil
+}
+
+func (e *Executor) executeCreateStage(ctx context.Context, execCtx ExecutionContext, sqlText string) (*ExecResult, error) {
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	stmt, err := parseCreateStageStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = e.stageMgr.CreateStage(
+		ctx,
+		schemaID,
+		stmt.Name,
+		"INTERNAL",
+		"",
+		"",
+	)
+	if err != nil {
+		// Para IF NOT EXISTS, ignore duplicate.
+		if stmt.IfNotExists && strings.Contains(strings.ToLower(err.Error()), "already exists") {
+			return &ExecResult{RowsAffected: 0}, nil
+		}
+
+		return nil, fmt.Errorf("create stage failed: %w", err)
+	}
+
+	return &ExecResult{RowsAffected: 0}, nil
+}
+
+func (e *Executor) executePut(ctx context.Context, execCtx ExecutionContext, sqlText string) (*ExecResult, error) {
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	stmt, err := parsePutStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(stmt.LocalPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open PUT source file %s: %w", stmt.LocalPath, err)
+	}
+	defer file.Close()
+
+	targetFileName := filepath.Base(stmt.LocalPath)
+
+	var reader io.Reader = file
+
+	if stmt.AutoCompress {
+		var buf bytes.Buffer
+
+		gz := gzip.NewWriter(&buf)
+		if _, err := io.Copy(gz, file); err != nil {
+			_ = gz.Close()
+			return nil, fmt.Errorf("failed to gzip PUT source file: %w", err)
+		}
+
+		if err := gz.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close gzip writer: %w", err)
+		}
+
+		reader = &buf
+
+		if !strings.HasSuffix(strings.ToLower(targetFileName), ".gz") {
+			targetFileName += ".gz"
+		}
+	}
+
+	stageFileName := targetFileName
+	if stmt.StagePath != "" {
+		stageFileName = strings.Trim(stmt.StagePath, "/") + "/" + targetFileName
+	}
+
+	if err := e.stageMgr.PutFile(ctx, schemaID, stmt.StageName, stageFileName, reader); err != nil {
+		return nil, fmt.Errorf("PUT failed: %w", err)
+	}
+
+	return &ExecResult{RowsAffected: 1}, nil
 }
 
 // convertValue converts database values to appropriate Go types.
@@ -609,4 +874,514 @@ func (e *Executor) QueryWithHistory(ctx context.Context, sessionID, queryID, sql
 	}
 
 	return result, execErr
+}
+
+func (e *Executor) BuildPutFileTransferPlan(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*PutFileTransferPlan, error) {
+	stmt, err := parsePutStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure the stage exists.
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	// Aqui precisamos expor/calcular o diretório físico do stage.
+	stageLocalDirectory, err := e.resolveLocalStageDirectory(ctx, schemaID, stmt.StageName, stmt.StagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PutFileTransferPlan{
+		LocalPath:           stmt.LocalPath,
+		Database:            stmt.Database,
+		Schema:              stmt.Schema,
+		StageName:           stmt.StageName,
+		StagePath:           stmt.StagePath,
+		StageLocalDirectory: stageLocalDirectory,
+		AutoCompress:        stmt.AutoCompress,
+		Overwrite:           stmt.Overwrite,
+	}, nil
+}
+
+func (e *Executor) resolveLocalStageDirectory(
+	ctx context.Context,
+	schemaID string,
+	stageName string,
+	stagePath string,
+) (string, error) {
+	stageName = strings.ToUpper(strings.TrimSpace(stageName))
+
+	// Garante que o stage existe na metadata.
+	if _, err := e.stageMgr.GetStage(ctx, schemaID, stageName); err != nil {
+		return "", fmt.Errorf("stage %s not found: %w", stageName, err)
+	}
+
+	baseDir := strings.TrimSpace(os.Getenv("STAGE_DIR"))
+	if baseDir == "" {
+		baseDir = "/data/stages"
+	}
+
+	dir := filepath.Join(baseDir, schemaID, stageName)
+
+	if stagePath != "" {
+		dir = filepath.Join(dir, filepath.FromSlash(strings.Trim(stagePath, "/")))
+	}
+
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return "", fmt.Errorf("create local stage directory failed: %w", err)
+	}
+
+	_ = os.Chmod(dir, 0o777)
+
+	return dir, nil
+}
+
+func parseCreateStageStatement(sqlText string) (*createStageStatement, error) {
+	normalized := strings.TrimSpace(sqlText)
+	upper := strings.ToUpper(normalized)
+
+	ifNotExists := strings.Contains(upper, "IF NOT EXISTS")
+
+	re := regexp.MustCompile(`(?is)CREATE\s+(?:OR\s+REPLACE\s+)?STAGE\s+(?:IF\s+NOT\s+EXISTS\s+)?([^\s;]+)`)
+	matches := re.FindStringSubmatch(normalized)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid CREATE STAGE statement: %s", sqlText)
+	}
+
+	database, schema, name := splitQualifiedObjectName(matches[1])
+
+	return &createStageStatement{
+		Database:    database,
+		Schema:      schema,
+		Name:        name,
+		IfNotExists: ifNotExists,
+	}, nil
+}
+
+func parsePutStatement(sqlText string) (*putStatement, error) {
+	normalized := strings.TrimSpace(sqlText)
+
+	re := regexp.MustCompile(`(?is)^PUT\s+'?file://([^'\s]+)'?\s+@([^\s]+)(.*)$`)
+	matches := re.FindStringSubmatch(normalized)
+	if len(matches) < 4 {
+		return nil, fmt.Errorf("invalid PUT statement: %s", sqlText)
+	}
+
+	localPath := matches[1]
+	stageRef := matches[2]
+	options := strings.ToUpper(matches[3])
+
+	stageObject, stagePath := splitStageRef(stageRef)
+	database, schema, stageName := splitQualifiedObjectName(stageObject)
+
+	return &putStatement{
+		LocalPath:    localPath,
+		Database:     database,
+		Schema:       schema,
+		StageName:    stageName,
+		StagePath:    stagePath,
+		AutoCompress: strings.Contains(options, "AUTO_COMPRESS") && strings.Contains(options, "TRUE"),
+		Overwrite:    strings.Contains(options, "OVERWRITE") && strings.Contains(options, "TRUE"),
+	}, nil
+}
+
+func splitStageRef(ref string) (stageObject string, stagePath string) {
+	ref = strings.TrimSpace(ref)
+	ref = strings.TrimPrefix(ref, "@")
+
+	parts := strings.SplitN(ref, "/", 2)
+	stageObject = parts[0]
+
+	if len(parts) > 1 {
+		stagePath = strings.Trim(parts[1], "/")
+	}
+
+	return stageObject, stagePath
+}
+
+func splitQualifiedObjectName(name string) (database string, schema string, object string) {
+	name = strings.TrimSpace(name)
+	name = strings.Trim(name, `"`)
+
+	parts := strings.Split(name, ".")
+
+	for i := range parts {
+		parts[i] = strings.Trim(parts[i], `"`)
+		parts[i] = strings.ToUpper(strings.TrimSpace(parts[i]))
+	}
+
+	switch len(parts) {
+	case 1:
+		return "", "", parts[0]
+	case 2:
+		return "", parts[0], parts[1]
+	default:
+		return parts[len(parts)-3], parts[len(parts)-2], parts[len(parts)-1]
+	}
+}
+
+func (e *Executor) resolveSchemaID(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	databaseName string,
+	schemaName string,
+) (string, error) {
+	databaseName = strings.TrimSpace(databaseName)
+	schemaName = strings.TrimSpace(schemaName)
+
+	if databaseName == "" {
+		databaseName = strings.TrimSpace(execCtx.Database)
+	}
+
+	if schemaName == "" {
+		schemaName = strings.TrimSpace(execCtx.CurrentSchema)
+	}
+
+	if databaseName == "" && schemaName == "" {
+		return "", fmt.Errorf(
+			"no current database or schema; use a fully-qualified object name",
+		)
+	}
+
+	if databaseName == "" {
+		return "", fmt.Errorf(
+			"no current database; use a fully-qualified object name",
+		)
+	}
+
+	if schemaName == "" {
+		return "", fmt.Errorf(
+			"no current schema; use a fully-qualified object name",
+		)
+	}
+
+	db, err := e.repo.GetDatabaseByName(ctx, databaseName)
+	if err != nil {
+		return "", fmt.Errorf("database %s not found: %w", databaseName, err)
+	}
+
+	schemaObj, err := e.repo.GetSchemaByName(ctx, db.ID, schemaName)
+	if err != nil {
+		return "", fmt.Errorf(
+			"schema %s not found in database %s: %w",
+			schemaName,
+			databaseName,
+			err,
+		)
+	}
+
+	return schemaObj.ID, nil
+}
+
+func qualifyDeleteWithSchema(sqlText string, schemaName string) string {
+	trimmed := strings.TrimSpace(sqlText)
+	upper := strings.ToUpper(trimmed)
+
+	// Do not rewrite simple cleanup deletes:
+	// DELETE FROM "E2E_TEST"
+	// DELETE FROM "E2E_TEST_INGEST"
+	if !strings.Contains(upper, " USING ") &&
+		!strings.Contains(upper, "\nUSING ") &&
+		!strings.Contains(upper, "\tUSING ") {
+		return sqlText
+	}
+
+	schemaName = strings.TrimSpace(schemaName)
+	schemaName = strings.Trim(schemaName, `"`)
+	if schemaName == "" {
+		return sqlText
+	}
+
+	// DELETE FROM "E2E_TEST" T
+	deleteFromRe := regexp.MustCompile(`(?i)\bDELETE\s+FROM\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)(\s+[A-Za-z_][A-Za-z0-9_]*)?`)
+
+	sqlText = deleteFromRe.ReplaceAllStringFunc(sqlText, func(match string) string {
+		parts := strings.Fields(match)
+		if len(parts) < 3 {
+			return match
+		}
+
+		tableRef := parts[2]
+
+		if strings.Contains(tableRef, ".") {
+			return match
+		}
+
+		tableName := strings.Trim(tableRef, `"`)
+		qualified := buildDuckDBQualifiedTableName(schemaName, tableName)
+
+		if len(parts) > 3 {
+			return "DELETE FROM " + qualified + " " + parts[3]
+		}
+
+		return "DELETE FROM " + qualified
+	})
+
+	// USING "E2E_TEST_INGEST" S
+	usingRe := regexp.MustCompile(`(?i)\bUSING\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)(\s+[A-Za-z_][A-Za-z0-9_]*)?`)
+
+	sqlText = usingRe.ReplaceAllStringFunc(sqlText, func(match string) string {
+		parts := strings.Fields(match)
+		if len(parts) < 2 {
+			return match
+		}
+
+		tableRef := parts[1]
+
+		if strings.Contains(tableRef, ".") {
+			return match
+		}
+
+		// Do not touch USING (
+		if strings.HasPrefix(tableRef, "(") {
+			return match
+		}
+
+		tableName := strings.Trim(tableRef, `"`)
+		qualified := buildDuckDBQualifiedTableName(schemaName, tableName)
+
+		if len(parts) > 2 {
+			return "USING " + qualified + " " + parts[2]
+		}
+
+		return "USING " + qualified
+	})
+
+	// FROM "E2E_TEST_INGEST" inside subqueries.
+	fromRe := regexp.MustCompile(`(?i)\bFROM\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)(\s+[A-Za-z_][A-Za-z0-9_]*)?`)
+
+	sqlText = fromRe.ReplaceAllStringFunc(sqlText, func(match string) string {
+		parts := strings.Fields(match)
+		if len(parts) < 2 {
+			return match
+		}
+
+		tableRef := parts[1]
+
+		if strings.Contains(tableRef, ".") {
+			return match
+		}
+
+		if strings.HasPrefix(tableRef, "(") || strings.HasPrefix(tableRef, "@") {
+			return match
+		}
+
+		tableName := strings.Trim(tableRef, `"`)
+		qualified := buildDuckDBQualifiedTableName(schemaName, tableName)
+
+		if len(parts) > 2 {
+			return "FROM " + qualified + " " + parts[2]
+		}
+
+		return "FROM " + qualified
+	})
+
+	return sqlText
+}
+
+func isRemoveStatement(sqlText string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(sqlText)), "REMOVE ")
+}
+
+func (e *Executor) executeRemove(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*ExecResult, error) {
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	stmt, err := parseRemoveStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := e.stageMgr.ListFiles(ctx, schemaID, stmt.StageName, stmt.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stage files for REMOVE: %w", err)
+	}
+
+	var removed int64
+
+	for _, file := range files {
+		if stmt.StagePath != "" && !strings.HasPrefix(file.Name, stmt.StagePath) {
+			continue
+		}
+
+		if err := e.stageMgr.RemoveFile(ctx, schemaID, stmt.StageName, file.Name); err != nil {
+			return nil, fmt.Errorf("failed to remove stage file %s: %w", file.Name, err)
+		}
+
+		removed++
+	}
+
+	return &ExecResult{RowsAffected: removed}, nil
+}
+
+func parseRemoveStatement(sqlText string) (*removeStatement, error) {
+	normalized := strings.TrimSpace(sqlText)
+
+	re := regexp.MustCompile(`(?is)^REMOVE\s+@([^\s]+)(?:\s+PATTERN\s*=\s*'([^']+)')?\s*;?$`)
+	matches := re.FindStringSubmatch(normalized)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid REMOVE statement: %s", sqlText)
+	}
+
+	stageRef := strings.TrimSpace(matches[1])
+
+	stageObject, stagePath := splitStageRef(stageRef)
+	database, schema, stageName := splitQualifiedObjectName(stageObject)
+
+	stmt := &removeStatement{
+		Database:  database,
+		Schema:    schema,
+		StageName: stageName,
+		StagePath: strings.Trim(stagePath, "/"),
+	}
+
+	if len(matches) > 2 {
+		stmt.Pattern = strings.TrimSpace(matches[2])
+	}
+
+	return stmt, nil
+}
+
+func isListStatement(sqlText string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(sqlText)), "LIST ")
+}
+
+func (e *Executor) executeList(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*ExecResult, error) {
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	stmt, err := parseListStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := e.stageMgr.ListFiles(ctx, schemaID, stmt.StageName, stmt.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stage files: %w", err)
+	}
+
+	var count int64
+
+	for _, file := range files {
+		if stmt.StagePath != "" && !strings.HasPrefix(file.Name, stmt.StagePath) {
+			continue
+		}
+
+		count++
+	}
+
+	return &ExecResult{
+		RowsAffected: count,
+	}, nil
+}
+
+func parseListStatement(sqlText string) (*listStatement, error) {
+	normalized := strings.TrimSpace(sqlText)
+
+	re := regexp.MustCompile(`(?is)^LIST\s+@([^\s]+)(?:\s+PATTERN\s*=\s*'([^']+)')?\s*;?$`)
+	matches := re.FindStringSubmatch(normalized)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid LIST statement: %s", sqlText)
+	}
+
+	stageRef := strings.TrimSpace(matches[1])
+
+	stageObject, stagePath := splitStageRef(stageRef)
+	database, schema, stageName := splitQualifiedObjectName(stageObject)
+
+	stmt := &listStatement{
+		Database:  database,
+		Schema:    schema,
+		StageName: stageName,
+		StagePath: strings.Trim(stagePath, "/"),
+	}
+
+	if len(matches) > 2 {
+		stmt.Pattern = strings.TrimSpace(matches[2])
+	}
+
+	return stmt, nil
+}
+
+func (e *Executor) QueryList(
+	ctx context.Context,
+	execCtx ExecutionContext,
+	sqlText string,
+) (*Result, error) {
+	if e.stageMgr == nil {
+		return nil, fmt.Errorf("stage manager not configured")
+	}
+
+	stmt, err := parseListStatement(sqlText)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID, err := e.resolveSchemaID(ctx, execCtx, stmt.Database, stmt.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := e.stageMgr.ListFiles(ctx, schemaID, stmt.StageName, stmt.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stage files: %w", err)
+	}
+
+	// Reusa o próprio Query() para criar Columns/ColumnTypes no formato correto do projeto.
+	result, err := e.Query(ctx, `SELECT '' AS name, 0::BIGINT AS size WHERE FALSE`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build LIST result metadata: %w", err)
+	}
+
+	rows := make([][]interface{}, 0)
+
+	for _, file := range files {
+		if stmt.StagePath != "" && !strings.HasPrefix(file.Name, stmt.StagePath) {
+			continue
+		}
+
+		rows = append(rows, []interface{}{
+			file.Name,
+			file.Size,
+		})
+	}
+
+	result.Rows = rows
+
+	return result, nil
+}
+
+func IsListStatement(sqlText string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(sqlText)), "LIST ")
 }

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -146,40 +146,79 @@ func (e *Executor) QueryWithBindings(ctx context.Context, sql string, bindings m
 }
 
 // applyBindings replaces :N placeholders with actual values from bindings.
-// Snowflake uses :1, :2, etc. for positional parameters.
-func (e *Executor) applyBindings(sql string, bindings map[string]*QueryBindingValue) (string, error) {
-	// Get binding keys sorted in descending order to avoid :1 replacing :10, :11, etc.
-	keys := make([]int, 0, len(bindings))
-	for k := range bindings {
-		pos, err := strconv.Atoi(k)
-		if err != nil {
-			return "", fmt.Errorf("invalid binding key %q: must be a number", k)
+// Snowflake uses :1, :2 or :v1, :v2, etc. for positional parameters.
+func (e *Executor) applyBindings(
+	sql string,
+	bindings map[string]*QueryBindingValue,
+) (string, error) {
+	normalized := make(map[string]*QueryBindingValue, len(bindings))
+
+	for key, binding := range bindings {
+		normalizedKey := normalizeBindingKey(key)
+		if normalizedKey == "" {
+			return "", fmt.Errorf("invalid binding key %q", key)
 		}
+
+		normalized[normalizedKey] = binding
+	}
+
+	keys := make([]int, 0, len(normalized))
+	for key := range normalized {
+		pos, err := strconv.Atoi(key)
+		if err != nil {
+			return "", fmt.Errorf("invalid binding key %q: must be numeric after normalization", key)
+		}
+
 		keys = append(keys, pos)
 	}
+
 	sort.Sort(sort.Reverse(sort.IntSlice(keys)))
 
 	result := sql
+
 	for _, pos := range keys {
 		key := strconv.Itoa(pos)
-		binding := bindings[key]
+		binding := normalized[key]
 		if binding == nil {
 			continue
 		}
 
-		placeholder := ":" + key
 		value, err := formatBindingValue(binding)
 		if err != nil {
 			return "", fmt.Errorf("error formatting binding %s: %w", key, err)
 		}
 
-		result = strings.ReplaceAll(result, placeholder, value)
+		placeholders := []string{
+			":" + key,
+			":v" + key,
+			":V" + key,
+		}
+
+		for _, placeholder := range placeholders {
+			result = strings.ReplaceAll(result, placeholder, value)
+		}
 	}
 
-	// Also handle ? placeholders (positional, 1-based)
-	result = e.replaceQuestionMarkPlaceholders(result, bindings)
+	result = e.replaceQuestionMarkPlaceholders(result, normalized)
 
 	return result, nil
+}
+
+func normalizeBindingKey(key string) string {
+	key = strings.TrimSpace(key)
+	key = strings.TrimPrefix(key, ":")
+	key = strings.TrimPrefix(key, "v")
+	key = strings.TrimPrefix(key, "V")
+
+	if key == "" {
+		return ""
+	}
+
+	if _, err := strconv.Atoi(key); err != nil {
+		return ""
+	}
+
+	return key
 }
 
 // replaceQuestionMarkPlaceholders replaces ? placeholders with binding values.

--- a/pkg/query/executor_test.go
+++ b/pkg/query/executor_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
@@ -688,5 +689,71 @@ func TestTransactionClassifier(t *testing.T) {
 				t.Errorf("IsRollback(%q) = %v, want %v", tt.sql, got, tt.isRollback)
 			}
 		})
+	}
+}
+
+func TestExecutorApplyBindingsSupportsGosnowflakeVPlaceholders(t *testing.T) {
+	executor := &Executor{}
+
+	sqlText := `
+		SELECT COLUMN_NAME
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = :v1
+		  AND TABLE_NAME = :v2
+	`
+
+	bindings := map[string]*BindingValue{
+		"1": {
+			Type:  "TEXT",
+			Value: "MAIN",
+		},
+		"2": {
+			Type:  "TEXT",
+			Value: "E2E_TEST",
+		},
+	}
+
+	got, err := executor.applyBindings(sqlText, bindings)
+	if err != nil {
+		t.Fatalf("applyBindings failed: %v", err)
+	}
+
+	if strings.Contains(got, ":v1") || strings.Contains(got, ":v2") {
+		t.Fatalf("expected :v placeholders to be replaced, got: %s", got)
+	}
+
+	if !strings.Contains(got, "TABLE_SCHEMA = 'MAIN'") {
+		t.Fatalf("expected schema binding to be replaced, got: %s", got)
+	}
+
+	if !strings.Contains(got, "TABLE_NAME = 'E2E_TEST'") {
+		t.Fatalf("expected table binding to be replaced, got: %s", got)
+	}
+}
+
+func TestExecutorApplyBindingsSupportsVKeys(t *testing.T) {
+	executor := &Executor{}
+
+	sqlText := `SELECT * FROM T WHERE A = :v1 AND B = :v2`
+
+	bindings := map[string]*BindingValue{
+		"v1": {
+			Type:  "TEXT",
+			Value: "foo",
+		},
+		"v2": {
+			Type:  "TEXT",
+			Value: "bar",
+		},
+	}
+
+	got, err := executor.applyBindings(sqlText, bindings)
+	if err != nil {
+		t.Fatalf("applyBindings failed: %v", err)
+	}
+
+	expected := `SELECT * FROM T WHERE A = 'foo' AND B = 'bar'`
+	if got != expected {
+		t.Fatalf("unexpected SQL:\nexpected: %s\nactual:   %s", expected, got)
 	}
 }

--- a/pkg/query/merge_processor.go
+++ b/pkg/query/merge_processor.go
@@ -38,12 +38,15 @@ type WhenClause struct {
 
 // MergeStatement represents a parsed MERGE INTO statement.
 type MergeStatement struct {
-	TargetTable string       // Target table name (may include db.schema.table)
-	TargetAlias string       // Alias for target table
-	SourceTable string       // Source table name or subquery
-	SourceAlias string       // Alias for source table
-	OnCondition string       // JOIN condition
-	WhenClauses []WhenClause // List of WHEN clauses
+	OriginalSQL    string
+	TargetDatabase string       // Target Database
+	TargetSchema   string       // Target Schema
+	TargetTable    string       // Target table name (may include db.schema.table)
+	TargetAlias    string       // Alias for target table
+	SourceTable    string       // Source table name or subquery
+	SourceAlias    string       // Alias for source table
+	OnCondition    string       // JOIN condition
+	WhenClauses    []WhenClause // List of WHEN clauses
 }
 
 // mergePatterns holds pre-compiled regex patterns for MERGE statement parsing.
@@ -68,7 +71,7 @@ func newMergePatterns() *mergePatterns {
 		// MERGE INTO target [AS alias] - alias must not be USING
 		mergeInto: regexp.MustCompile(`(?i)MERGE\s+INTO\s+(\S+)(?:\s+AS\s+(\w+)|\s+([a-zA-Z_][a-zA-Z0-9_]*))?(?:\s+USING)`),
 		// USING source [AS alias] or USING (subquery) [AS alias] - alias must not be ON
-		using: regexp.MustCompile(`(?i)USING\s+(\([^)]+\)|[^\s(]+)(?:\s+AS\s+(\w+)|\s+([a-zA-Z_][a-zA-Z0-9_]*))?(?:\s+ON)`),
+		using: regexp.MustCompile(`(?is)USING\s+(.+?)\s+(?:AS\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s+ON\s+`),
 		// ON condition - we'll extract until WHEN in the parsing logic
 		onCondition: regexp.MustCompile(`(?i)\bON\s+(.+)`),
 		// WHEN MATCHED [AND condition] THEN
@@ -110,14 +113,20 @@ func NewMergeProcessor(executor *Executor) *MergeProcessor {
 func (h *MergeProcessor) ParseMergeStatement(sql string) (*MergeStatement, error) {
 	sql = strings.TrimSpace(sql)
 
-	stmt := &MergeStatement{}
+	stmt := &MergeStatement{
+		OriginalSQL: sql,
+	}
 
 	// Parse MERGE INTO target [AS alias]
 	mergeMatch := h.patterns.mergeInto.FindStringSubmatch(sql)
 	if len(mergeMatch) < 2 {
 		return nil, fmt.Errorf("invalid MERGE INTO syntax: missing target table")
 	}
-	stmt.TargetTable = mergeMatch[1]
+	targetDatabase, targetSchema, targetTable := splitQualifiedObjectName(mergeMatch[1])
+
+	stmt.TargetDatabase = targetDatabase
+	stmt.TargetSchema = targetSchema
+	stmt.TargetTable = targetTable
 	// Check for alias (either with AS or without)
 	if len(mergeMatch) > 2 && mergeMatch[2] != "" {
 		stmt.TargetAlias = mergeMatch[2]
@@ -130,12 +139,10 @@ func (h *MergeProcessor) ParseMergeStatement(sql string) (*MergeStatement, error
 	if len(usingMatch) < 2 {
 		return nil, fmt.Errorf("invalid MERGE syntax: missing USING clause")
 	}
-	stmt.SourceTable = usingMatch[1]
-	// Check for alias (either with AS or without)
+	stmt.SourceTable = strings.TrimSpace(usingMatch[1])
+
 	if len(usingMatch) > 2 && usingMatch[2] != "" {
-		stmt.SourceAlias = usingMatch[2]
-	} else if len(usingMatch) > 3 && usingMatch[3] != "" {
-		stmt.SourceAlias = usingMatch[3]
+		stmt.SourceAlias = strings.TrimSpace(usingMatch[2])
 	}
 
 	// Parse ON condition - extract until first WHEN keyword
@@ -350,19 +357,21 @@ func splitByCommaRespectingParens(s string) []string {
 func (h *MergeProcessor) ExecuteMerge(ctx context.Context, stmt *MergeStatement) (*MergeResult, error) {
 	result := &MergeResult{}
 
-	// Build the native MERGE SQL
-	mergeSQL := h.buildMergeSQL(stmt)
+	mergeSQL := strings.TrimSpace(stmt.OriginalSQL)
+	if mergeSQL == "" {
+		mergeSQL = h.buildMergeSQL(stmt)
+	}
 
-	// Try native execution first (DuckDB 1.4+ supports MERGE)
 	execResult, err := h.executor.executeRaw(ctx, mergeSQL)
 	if err == nil {
-		// Native MERGE succeeded
-		// DuckDB returns total rows affected; we can't distinguish insert/update/delete
 		result.RowsUpdated = execResult.RowsAffected
 		return result, nil
 	}
 
-	// If native MERGE fails (older DuckDB version), decompose into separate statements
+	if stmt.TargetSchema != "" {
+		stmt.SourceTable = qualifySourceTableRefs(stmt.SourceTable, stmt.TargetSchema)
+	}
+
 	return h.executeDecomposedMerge(ctx, stmt)
 }
 
@@ -491,52 +500,43 @@ func (h *MergeProcessor) executeDecomposedMerge(ctx context.Context, stmt *Merge
 
 // executeMatchedUpdate executes UPDATE for WHEN MATCHED THEN UPDATE.
 func (h *MergeProcessor) executeMatchedUpdate(ctx context.Context, stmt *MergeStatement, when *WhenClause) (int64, error) {
-	// Build: UPDATE target SET ... FROM source WHERE join_condition [AND when_condition]
-	// DuckDB requires the table name (not alias) in UPDATE clause
 	var sb strings.Builder
 
+	targetTableName := h.targetTableName(stmt)
+
 	sb.WriteString("UPDATE ")
-	sb.WriteString(stmt.TargetTable)
+	sb.WriteString(targetTableName)
+
+	if stmt.TargetAlias != "" {
+		sb.WriteString(" AS ")
+		sb.WriteString(stmt.TargetAlias)
+	}
+
 	sb.WriteString(" SET ")
 
-	// Replace target alias with table name in SET clauses
 	var sets []string
 	for _, sc := range when.SetClauses {
-		col := sc.Column
-		val := sc.Value
-		// If column has alias prefix matching target alias, replace with table name
-		if stmt.TargetAlias != "" {
-			col = strings.Replace(col, stmt.TargetAlias+".", stmt.TargetTable+".", 1)
-		}
-		sets = append(sets, col+" = "+val)
+		col := unqualifyColumn(sc.Column)
+
+		sets = append(sets, col+" = "+sc.Value)
 	}
+
 	sb.WriteString(strings.Join(sets, ", "))
 
-	// FROM clause for the source
 	sb.WriteString(" FROM ")
 	sb.WriteString(stmt.SourceTable)
+
 	if stmt.SourceAlias != "" {
 		sb.WriteString(" AS ")
 		sb.WriteString(stmt.SourceAlias)
 	}
 
-	// WHERE clause with join condition
-	// Replace target alias with table name in condition
-	onCondition := stmt.OnCondition
-	if stmt.TargetAlias != "" {
-		onCondition = strings.ReplaceAll(onCondition, stmt.TargetAlias+".", stmt.TargetTable+".")
-	}
 	sb.WriteString(" WHERE ")
-	sb.WriteString(onCondition)
+	sb.WriteString(stmt.OnCondition)
 
-	// Additional AND condition
 	if when.Condition != "" {
-		condition := when.Condition
-		if stmt.TargetAlias != "" {
-			condition = strings.ReplaceAll(condition, stmt.TargetAlias+".", stmt.TargetTable+".")
-		}
 		sb.WriteString(" AND ")
-		sb.WriteString(condition)
+		sb.WriteString(when.Condition)
 	}
 
 	execResult, err := h.executor.executeRaw(ctx, sb.String())
@@ -552,8 +552,10 @@ func (h *MergeProcessor) executeMatchedDelete(ctx context.Context, stmt *MergeSt
 	// Build: DELETE FROM target USING source WHERE join_condition [AND when_condition]
 	var sb strings.Builder
 
+	targetTableName := h.targetTableName(stmt)
+
 	sb.WriteString("DELETE FROM ")
-	sb.WriteString(stmt.TargetTable)
+	sb.WriteString(targetTableName)
 
 	// USING clause for the source (DuckDB syntax)
 	sb.WriteString(" USING ")
@@ -586,8 +588,10 @@ func (h *MergeProcessor) executeNotMatchedInsert(ctx context.Context, stmt *Merg
 	// Build: INSERT INTO target (cols) SELECT vals FROM source WHERE NOT EXISTS (...)
 	var sb strings.Builder
 
+	targetTableName := h.targetTableName(stmt)
+
 	sb.WriteString("INSERT INTO ")
-	sb.WriteString(stmt.TargetTable)
+	sb.WriteString(targetTableName)
 
 	if len(when.InsertCols) > 0 {
 		sb.WriteString(" (")
@@ -607,7 +611,7 @@ func (h *MergeProcessor) executeNotMatchedInsert(ctx context.Context, stmt *Merg
 
 	// WHERE NOT EXISTS to find non-matching rows
 	sb.WriteString(" WHERE NOT EXISTS (SELECT 1 FROM ")
-	sb.WriteString(stmt.TargetTable)
+	sb.WriteString(targetTableName)
 	if stmt.TargetAlias != "" {
 		sb.WriteString(" AS ")
 		sb.WriteString(stmt.TargetAlias)
@@ -628,4 +632,52 @@ func (h *MergeProcessor) executeNotMatchedInsert(ctx context.Context, stmt *Merg
 	}
 
 	return execResult.RowsAffected, nil
+}
+
+func unqualifyColumn(column string) string {
+	column = strings.TrimSpace(column)
+
+	if idx := strings.LastIndex(column, "."); idx >= 0 {
+		return strings.TrimSpace(column[idx+1:])
+	}
+
+	return column
+}
+
+func (h *MergeProcessor) targetTableName(stmt *MergeStatement) string {
+	return buildDuckDBQualifiedTableName(stmt.TargetSchema, stmt.TargetTable)
+}
+
+func qualifySourceTableRefs(sql string, schemaName string) string {
+	schemaName = strings.TrimSpace(schemaName)
+	schemaName = strings.Trim(schemaName, `"`)
+	if schemaName == "" {
+		return sql
+	}
+
+	re := regexp.MustCompile(`(?i)\bFROM\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)`)
+
+	return re.ReplaceAllStringFunc(sql, func(match string) string {
+		parts := strings.Fields(match)
+		if len(parts) < 2 {
+			return match
+		}
+
+		tableRef := parts[1]
+
+		// Already qualified.
+		if strings.Contains(tableRef, ".") {
+			return match
+		}
+
+		// Do not touch stages or subqueries.
+		if strings.HasPrefix(tableRef, "@") || strings.HasPrefix(tableRef, "(") {
+			return match
+		}
+
+		tableName := strings.Trim(tableRef, `"`)
+		qualified := buildDuckDBQualifiedTableName(schemaName, tableName)
+
+		return "FROM " + qualified
+	})
 }

--- a/pkg/query/name_rewriter.go
+++ b/pkg/query/name_rewriter.go
@@ -1,0 +1,186 @@
+package query
+
+import (
+	"regexp"
+	"strings"
+)
+
+func rewriteTableRefsToPhysicalDuckDB(sqlText string, defaultSchema string) string {
+	defaultSchema = normalizeSnowflakeIdent(defaultSchema)
+
+	keywords := []string{
+		`CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?`,
+		`DROP\s+TABLE(?:\s+IF\s+EXISTS)?`,
+		`DELETE\s+FROM`,
+		`INSERT\s+INTO`,
+		`UPDATE`,
+		`MERGE\s+INTO`,
+		`FROM`,
+		`JOIN`,
+		`USING`,
+		`COPY\s+INTO`,
+	}
+
+	for _, keyword := range keywords {
+		sqlText = rewriteKeywordTableRef(sqlText, keyword, defaultSchema)
+	}
+
+	return sqlText
+}
+
+func rewriteKeywordTableRef(sqlText string, keyword string, defaultSchema string) string {
+	re := regexp.MustCompile(`(?is)\b(` + keyword + `)\s+((?:"[^"]+"|[A-Za-z_][A-Za-z0-9_]*)(?:\s*\.\s*(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_]*)){0,2})`)
+
+	return re.ReplaceAllStringFunc(sqlText, func(match string) string {
+		parts := re.FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
+
+		kw := parts[1]
+		ref := strings.TrimSpace(parts[2])
+
+		if shouldSkipTableRewrite(ref) {
+			return match
+		}
+
+		_, schema, table, alreadyPhysical := parseSnowflakeObjectRef(ref)
+
+		if table == "" {
+			return match
+		}
+
+		// Nome inteiro entre aspas: não mexe.
+		// Ex: "INFORMATION_SCHEMA.COLUMNS", "PUBLIC_E2E_TEST"
+		if alreadyPhysical {
+			return match
+		}
+
+		if schema == "" {
+			schema = defaultSchema
+		}
+
+		if schema == "" {
+			return kw + " " + quoteDuckDBIdent(table)
+		}
+
+		return kw + " " + quoteDuckDBIdent(schema) + "." + quoteDuckDBIdent(table)
+	})
+}
+
+func shouldSkipTableRewrite(ref string) bool {
+	ref = strings.TrimSpace(ref)
+
+	return ref == "" ||
+		strings.HasPrefix(ref, "(") ||
+		strings.HasPrefix(ref, "@") ||
+		strings.Contains(strings.ToUpper(ref), "INFORMATION_SCHEMA.")
+}
+
+func parseSnowflakeObjectRef(ref string) (database string, schema string, table string, alreadyPhysical bool) {
+	ref = strings.TrimSpace(ref)
+
+	// Se o identificador inteiro está entre aspas, não divida por ponto.
+	// Exemplos:
+	// "INFORMATION_SCHEMA.COLUMNS"
+	// "PUBLIC_E2E_TEST"
+	if isSingleQuotedIdentifier(ref) {
+		ident := normalizeSnowflakeIdent(ref)
+
+		// Se tem ponto dentro das aspas, considera nome literal, não schema.table.
+		if strings.Contains(ident, ".") {
+			return "", "", ident, true
+		}
+
+		// Se já parece nome físico do DuckDB, também não reescreve.
+		if strings.Contains(ident, "_") {
+			return "", "", ident, true
+		}
+
+		return "", "", ident, false
+	}
+
+	parts := splitObjectRefParts(ref)
+
+	switch len(parts) {
+	case 1:
+		return "", "", normalizeSnowflakeIdent(parts[0]), false
+	case 2:
+		return "", normalizeSnowflakeIdent(parts[0]), normalizeSnowflakeIdent(parts[1]), false
+	case 3:
+		return normalizeSnowflakeIdent(parts[0]), normalizeSnowflakeIdent(parts[1]), normalizeSnowflakeIdent(parts[2]), false
+	default:
+		return "", "", normalizeSnowflakeIdent(ref), false
+	}
+}
+
+func isSingleQuotedIdentifier(ref string) bool {
+	ref = strings.TrimSpace(ref)
+
+	if len(ref) < 2 {
+		return false
+	}
+
+	return strings.HasPrefix(ref, `"`) && strings.HasSuffix(ref, `"`) && countUnescapedDotsOutsideQuotes(ref) == 0
+}
+
+func countUnescapedDotsOutsideQuotes(ref string) int {
+	inDoubleQuote := false
+	count := 0
+
+	for _, r := range ref {
+		switch r {
+		case '"':
+			inDoubleQuote = !inDoubleQuote
+		case '.':
+			if !inDoubleQuote {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+func splitObjectRefParts(ref string) []string {
+	var parts []string
+	var current strings.Builder
+	inDoubleQuote := false
+
+	for _, r := range ref {
+		switch r {
+		case '"':
+			inDoubleQuote = !inDoubleQuote
+			current.WriteRune(r)
+		case '.':
+			if inDoubleQuote {
+				current.WriteRune(r)
+			} else {
+				parts = append(parts, strings.TrimSpace(current.String()))
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, strings.TrimSpace(current.String()))
+	}
+
+	return parts
+}
+
+func normalizeSnowflakeIdent(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"`)
+	value = strings.ReplaceAll(value, `""`, `"`)
+	return strings.ToUpper(value)
+}
+
+func quoteDuckDBIdent(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"`)
+	value = strings.ReplaceAll(value, `"`, `""`)
+	return `"` + value + `"`
+}

--- a/pkg/stage/manager.go
+++ b/pkg/stage/manager.go
@@ -2,6 +2,7 @@
 package stage
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -131,31 +132,24 @@ func (m *Manager) PutFile(ctx context.Context, schemaID, stageName, fileName str
 
 // GetFile retrieves a file from a stage.
 func (m *Manager) GetFile(ctx context.Context, schemaID, stageName, fileName string) (io.ReadCloser, error) {
-	stage, err := m.repo.GetStageByName(ctx, schemaID, stageName)
+	stagePath := filepath.Join(m.stageDir, schemaID, strings.ToUpper(stageName), fileName)
+
+	file, err := os.Open(stagePath)
 	if err != nil {
 		return nil, err
 	}
 
-	if strings.ToUpper(stage.StageType) != "INTERNAL" && stage.StageType != "" {
-		return nil, fmt.Errorf("GET operation only supported for internal stages")
-	}
-
-	stageDir := m.getStageDir(schemaID, stage.Name)
-
-	// Sanitize file name to prevent directory traversal
-	cleanName := filepath.Clean(fileName)
-	if strings.HasPrefix(cleanName, "..") || filepath.IsAbs(cleanName) {
-		return nil, fmt.Errorf("invalid file name: %s", fileName)
-	}
-
-	filePath := filepath.Join(stageDir, cleanName)
-
-	file, err := os.Open(filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("file %s not found in stage %s", fileName, stageName)
+	if strings.HasSuffix(strings.ToLower(fileName), ".gz") {
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
-		return nil, fmt.Errorf("failed to open file: %w", err)
+
+		return &multiReadCloser{
+			Reader:  gz,
+			closers: []io.Closer{gz, file},
+		}, nil
 	}
 
 	return file, nil
@@ -265,4 +259,21 @@ func (m *Manager) GetStageDirectory(ctx context.Context, schemaID, stageName str
 	}
 
 	return m.getStageDir(schemaID, stage.Name), nil
+}
+
+type multiReadCloser struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (m *multiReadCloser) Close() error {
+	var firstErr error
+
+	for _, closer := range m.closers {
+		if err := closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
 }

--- a/server/handlers/query.go
+++ b/server/handlers/query.go
@@ -7,7 +7,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/nnnkkk7/snowflake-emulator/pkg/config"
@@ -57,6 +59,12 @@ func (h *QueryHandler) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Printf(
+		"gosnowflake query request sql=%q bindings=%+v",
+		req.SQLText,
+		req.Bindings,
+	)
+
 	if req.SQLText == "" {
 		sendError(w, apierror.NewSnowflakeError(apierror.CodeInvalidParameter, "SQL text is required"))
 		return
@@ -65,12 +73,31 @@ func (h *QueryHandler) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 	// Classify the SQL statement
 	classification := query.ClassifySQL(req.SQLText)
 
+	execCtx := query.ExecutionContext{
+		SessionID:     fmt.Sprintf("%d", sess.ID),
+		Database:      sess.Database,
+		CurrentSchema: sess.CurrentSchema,
+	}
+
+	if query.IsListStatement(req.SQLText) {
+		h.executeListQuery(w, ctx, execCtx, req.SQLText)
+		return
+	}
+	if query.NewClassifier().IsPut(req.SQLText) {
+		h.executePutFileTransfer(w, ctx, execCtx, req.SQLText)
+		return
+	}
+
 	bindings := convertGosnowflakeBindings(req.Bindings)
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(req.SQLText)), "LIST ") {
+		h.executeListQuery(w, ctx, execCtx, req.SQLText)
+		return
+	}
 
 	if classification.IsQuery {
 		h.executeQuery(w, ctx, sessionID, req.SQLText, bindings)
 	} else {
-		h.executeDML(w, ctx, sessionID, req.SQLText, bindings)
+		h.executeDML(w, ctx, execCtx, req.SQLText, bindings)
 	}
 }
 
@@ -106,7 +133,7 @@ func (h *QueryHandler) executeQuery(w http.ResponseWriter, ctx context.Context, 
 	}
 
 	rowType := result.ColumnTypes
-	rowSet := convertRowsToStrings(result.Rows)
+	rowSet := convertRowsToSnowflakeRowSet(result.Rows)
 
 	resp := types.QueryResponse{
 		Success: true,
@@ -128,7 +155,7 @@ func (h *QueryHandler) executeQuery(w http.ResponseWriter, ctx context.Context, 
 }
 
 // executeDML executes a DML/DDL statement with gosnowflake protocol.
-func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, sessionID int64, sqlText string, bindings map[string]*query.BindingValue) { //nolint:revive // context-as-argument: keeping w first for handler consistency
+func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, execCtx query.ExecutionContext, sqlText string, bindings map[string]*query.BindingValue) { //nolint:revive // context-as-argument: keeping w first for handler consistency
 	// Generate unique query ID
 	queryID := generateQueryID()
 
@@ -136,11 +163,11 @@ func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, se
 	var err error
 
 	if len(bindings) > 0 {
-		result, err = h.executor.ExecuteWithBindings(ctx, sqlText, bindings)
+		result, err = h.executor.ExecuteWithBindingsAndContext(ctx, execCtx, sqlText, bindings)
 	} else {
-		result, err = h.executor.ExecuteWithHistory(
+		result, err = h.executor.ExecuteWithHistoryAndContext(
 			ctx,
-			fmt.Sprintf("%d", sessionID),
+			execCtx,
 			queryID,
 			sqlText,
 		)
@@ -151,7 +178,7 @@ func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, se
 			w,
 			apierror.WrapError(
 				apierror.CodeSQLExecutionError,
-				"statement execution failed",
+				fmt.Sprintf("statement execution failed: %v", err),
 				err,
 			),
 		)
@@ -196,6 +223,54 @@ func (h *QueryHandler) AbortQuery(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+func (h *QueryHandler) executePutFileTransfer(
+	w http.ResponseWriter,
+	ctx context.Context,
+	execCtx query.ExecutionContext,
+	sqlText string,
+) {
+	queryID := generateQueryID()
+
+	plan, err := h.executor.BuildPutFileTransferPlan(ctx, execCtx, sqlText)
+	if err != nil {
+		sendError(
+			w,
+			apierror.WrapError(
+				apierror.CodeSQLExecutionError,
+				fmt.Sprintf("PUT file transfer planning failed: %v", err),
+				err,
+			),
+		)
+		return
+	}
+
+	resp := types.QueryResponse{
+		Success: true,
+		Data: &types.QuerySuccessData{
+			QueryID:           queryID,
+			SQLState:          apierror.SQLStateSuccess,
+			StatementTypeID:   0,
+			QueryResultFormat: config.QueryResultFormatJSON,
+
+			Command:           "UPLOAD",
+			SrcLocations:      []string{plan.LocalPath},
+			AutoCompress:      plan.AutoCompress,
+			SourceCompression: "AUTO_DETECT",
+			Overwrite:         plan.Overwrite,
+			Parallel:          1,
+			StageInfo: &types.StageInfo{
+				LocationType: "LOCAL_FS",
+				Location:     plan.StageLocalDirectory,
+				Path:         plan.StagePath,
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // generateQueryID generates a unique query ID.
 func generateQueryID() string {
 	bytes := make([]byte, 8)
@@ -221,6 +296,26 @@ func convertRowsToStrings(rows [][]interface{}) [][]string {
 		}
 		result[i] = strRow
 	}
+	return result
+}
+
+func convertRowsToSnowflakeRowSet(rows [][]interface{}) [][]interface{} {
+	result := make([][]interface{}, len(rows))
+
+	for i, row := range rows {
+		outRow := make([]interface{}, len(row))
+
+		for j, val := range row {
+			if val == nil {
+				outRow[j] = nil
+			} else {
+				outRow[j] = fmt.Sprintf("%v", val)
+			}
+		}
+
+		result[i] = outRow
+	}
+
 	return result
 }
 
@@ -276,4 +371,44 @@ func stringFromAny(value interface{}) string {
 	default:
 		return fmt.Sprint(v)
 	}
+}
+
+func (h *QueryHandler) executeListQuery(
+	w http.ResponseWriter,
+	ctx context.Context,
+	execCtx query.ExecutionContext,
+	sqlText string,
+) {
+	queryID := generateQueryID()
+
+	result, err := h.executor.QueryList(ctx, execCtx, sqlText)
+	if err != nil {
+		sendError(
+			w,
+			apierror.WrapError(
+				apierror.CodeSQLExecutionError,
+				fmt.Sprintf("LIST stage failed: %v", err),
+				err,
+			),
+		)
+		return
+	}
+
+	resp := types.QueryResponse{
+		Success: true,
+		Data: &types.QuerySuccessData{
+			QueryID:           queryID,
+			SQLState:          apierror.SQLStateSuccess,
+			StatementTypeID:   int64(config.StatementTypeSelect),
+			RowType:           result.ColumnTypes,
+			RowSet:            convertRowsToSnowflakeRowSet(result.Rows),
+			Total:             int64(len(result.Rows)),
+			Returned:          int64(len(result.Rows)),
+			QueryResultFormat: config.QueryResultFormatJSON,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/server/handlers/query.go
+++ b/server/handlers/query.go
@@ -65,34 +65,49 @@ func (h *QueryHandler) ExecuteQuery(w http.ResponseWriter, r *http.Request) {
 	// Classify the SQL statement
 	classification := query.ClassifySQL(req.SQLText)
 
+	bindings := convertGosnowflakeBindings(req.Bindings)
+
 	if classification.IsQuery {
-		h.executeQuery(w, ctx, sessionID, req.SQLText)
+		h.executeQuery(w, ctx, sessionID, req.SQLText, bindings)
 	} else {
-		h.executeDML(w, ctx, sessionID, req.SQLText)
+		h.executeDML(w, ctx, sessionID, req.SQLText, bindings)
 	}
 }
 
 // executeQuery executes a SELECT query with gosnowflake protocol.
-func (h *QueryHandler) executeQuery(w http.ResponseWriter, ctx context.Context, sessionID int64, sqlText string) { //nolint:revive // context-as-argument: keeping w first for handler consistency
+func (h *QueryHandler) executeQuery(w http.ResponseWriter, ctx context.Context, sessionID int64, sqlText string, bindings map[string]*query.BindingValue) { //nolint:revive // context-as-argument: keeping w first for handler consistency
 	// Generate unique query ID
 	queryID := generateQueryID()
 
-	// Execute query with history tracking
-	result, err := h.executor.QueryWithHistory(ctx, fmt.Sprintf("%d", sessionID), queryID, sqlText)
+	var result *query.Result
+	var err error
+
+	if len(bindings) > 0 {
+		result, err = h.executor.QueryWithBindings(ctx, sqlText, bindings)
+	} else {
+		result, err = h.executor.QueryWithHistory(
+			ctx,
+			fmt.Sprintf("%d", sessionID),
+			queryID,
+			sqlText,
+		)
+	}
+
 	if err != nil {
-		// Use apierror for error classification
-		// Include the underlying error in the message for debugging
-		sendError(w, apierror.WrapError(apierror.CodeSQLExecutionError, fmt.Sprintf("query execution failed: %v", err), err))
+		sendError(
+			w,
+			apierror.WrapError(
+				apierror.CodeSQLExecutionError,
+				fmt.Sprintf("query execution failed: %v", err),
+				err,
+			),
+		)
 		return
 	}
 
-	// Use column types captured from actual query result
 	rowType := result.ColumnTypes
-
-	// Convert all values to strings for gosnowflake protocol
 	rowSet := convertRowsToStrings(result.Rows)
 
-	// Build success response
 	resp := types.QueryResponse{
 		Success: true,
 		Data: &types.QuerySuccessData{
@@ -113,21 +128,38 @@ func (h *QueryHandler) executeQuery(w http.ResponseWriter, ctx context.Context, 
 }
 
 // executeDML executes a DML/DDL statement with gosnowflake protocol.
-func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, sessionID int64, sqlText string) { //nolint:revive // context-as-argument: keeping w first for handler consistency
+func (h *QueryHandler) executeDML(w http.ResponseWriter, ctx context.Context, sessionID int64, sqlText string, bindings map[string]*query.BindingValue) { //nolint:revive // context-as-argument: keeping w first for handler consistency
 	// Generate unique query ID
 	queryID := generateQueryID()
 
-	// Execute with history tracking
-	result, err := h.executor.ExecuteWithHistory(ctx, fmt.Sprintf("%d", sessionID), queryID, sqlText)
+	var result *query.ExecResult
+	var err error
+
+	if len(bindings) > 0 {
+		result, err = h.executor.ExecuteWithBindings(ctx, sqlText, bindings)
+	} else {
+		result, err = h.executor.ExecuteWithHistory(
+			ctx,
+			fmt.Sprintf("%d", sessionID),
+			queryID,
+			sqlText,
+		)
+	}
+
 	if err != nil {
-		sendError(w, apierror.WrapError(apierror.CodeSQLExecutionError, "statement execution failed", err))
+		sendError(
+			w,
+			apierror.WrapError(
+				apierror.CodeSQLExecutionError,
+				"statement execution failed",
+				err,
+			),
+		)
 		return
 	}
 
-	// Get statement type ID using the classifier
 	stmtTypeID := query.GetStatementTypeID(sqlText)
 
-	// Build success response
 	resp := types.QueryResponse{
 		Success: true,
 		Data: &types.QuerySuccessData{
@@ -190,4 +222,58 @@ func convertRowsToStrings(rows [][]interface{}) [][]string {
 		result[i] = strRow
 	}
 	return result
+}
+
+func convertGosnowflakeBindings(
+	input map[string]interface{},
+) map[string]*query.BindingValue {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]*query.BindingValue, len(input))
+
+	for key, raw := range input {
+		switch v := raw.(type) {
+		case map[string]interface{}:
+			binding := &query.BindingValue{
+				Type:  stringFromAny(v["type"]),
+				Value: stringFromAny(v["value"]),
+			}
+
+			if binding.Type == "" {
+				binding.Type = stringFromAny(v["TYPE"])
+			}
+			if binding.Value == "" {
+				binding.Value = stringFromAny(v["VALUE"])
+			}
+
+			if binding.Type == "" {
+				binding.Type = "TEXT"
+			}
+
+			result[key] = binding
+
+		default:
+			result[key] = &query.BindingValue{
+				Type:  "TEXT",
+				Value: fmt.Sprint(v),
+			}
+		}
+	}
+
+	return result
+}
+
+func stringFromAny(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+
+	switch v := value.(type) {
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
 }

--- a/server/handlers/rest_api_v2.go
+++ b/server/handlers/rest_api_v2.go
@@ -71,19 +71,40 @@ func (h *RestAPIv2Handler) SubmitStatement(w http.ResponseWriter, r *http.Reques
 	var execResult *query.ExecResult
 	var err error
 
+	execCtx := query.ExecutionContext{
+		Database:      req.Database,
+		CurrentSchema: req.Schema,
+	}
+
 	if classification.IsQuery {
 		// Handle SELECT, SHOW, DESCRIBE, EXPLAIN
 		if len(bindings) > 0 {
-			result, err = h.executor.QueryWithBindings(ctx, req.Statement, bindings)
+			result, err = h.executor.QueryWithBindings(
+				ctx,
+				req.Statement,
+				bindings,
+			)
 		} else {
-			result, err = h.executor.Query(ctx, req.Statement)
+			result, err = h.executor.Query(
+				ctx,
+				req.Statement,
+			)
 		}
 	} else {
 		// Handle DDL (CREATE, DROP, ALTER) and DML (INSERT, UPDATE, DELETE)
 		if len(bindings) > 0 {
-			execResult, err = h.executor.ExecuteWithBindings(ctx, req.Statement, bindings)
+			execResult, err = h.executor.ExecuteWithBindingsAndContext(
+				ctx,
+				execCtx,
+				req.Statement,
+				bindings,
+			)
 		} else {
-			execResult, err = h.executor.Execute(ctx, req.Statement)
+			execResult, err = h.executor.ExecuteWithContext(
+				ctx,
+				execCtx,
+				req.Statement,
+			)
 		}
 	}
 

--- a/server/handlers/session.go
+++ b/server/handlers/session.go
@@ -78,14 +78,20 @@ func (h *SessionHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set default database/schema if not provided
-	database := req.Data.DatabaseName
+	database := strings.TrimSpace(req.Data.DatabaseName)
+	if database == "" {
+		database = strings.TrimSpace(r.URL.Query().Get("databaseName"))
+	}
 	if database == "" {
 		database = config.DefaultDatabase
 	}
 
-	schema := req.Data.SchemaName
-	if schema == "" {
-		schema = config.DefaultSchema
+	schemaName := strings.TrimSpace(req.Data.SchemaName)
+	if schemaName == "" {
+		schemaName = strings.TrimSpace(r.URL.Query().Get("schemaName"))
+	}
+	if schemaName == "" {
+		schemaName = config.DefaultSchema
 	}
 
 	ctx := r.Context()
@@ -102,7 +108,7 @@ func (h *SessionHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create session with master token support
-	sess, err := h.sessionMgr.CreateSession(ctx, req.Data.LoginName, database, schema)
+	sess, err := h.sessionMgr.CreateSession(ctx, req.Data.LoginName, database, schemaName)
 	if err != nil {
 		sendError(w, apierror.NewSnowflakeError(apierror.CodeInternalError, "Failed to create session"))
 		return
@@ -149,7 +155,7 @@ func (h *SessionHandler) Login(w http.ResponseWriter, r *http.Request) {
 			Parameters:              parameters,
 			SessionInfo: types.SessionInfo{
 				DatabaseName:  database,
-				SchemaName:    schema,
+				SchemaName:    schemaName,
 				WarehouseName: req.Data.WarehouseName,
 				RoleName:      req.Data.RoleName,
 			},

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -112,10 +112,24 @@ type QuerySuccessData struct {
 	SQLState          string           `json:"sqlState,omitempty"`
 	StatementTypeID   int64            `json:"statementTypeId"`
 	RowType           []ColumnMetadata `json:"rowtype,omitempty"`
-	RowSet            [][]string       `json:"rowset,omitempty"`
+	RowSet            [][]interface{}  `json:"rowset,omitempty"`
 	Total             int64            `json:"total"`
 	Returned          int64            `json:"returned"`
 	QueryResultFormat string           `json:"queryResultFormat"`
+
+	Command           string     `json:"command,omitempty"`
+	SrcLocations      []string   `json:"src_locations,omitempty"`
+	StageInfo         *StageInfo `json:"stageInfo,omitempty"`
+	AutoCompress      bool       `json:"autoCompress,omitempty"`
+	SourceCompression string     `json:"sourceCompression,omitempty"`
+	Overwrite         bool       `json:"overwrite,omitempty"`
+	Parallel          int64      `json:"parallel,omitempty"`
+}
+
+type StageInfo struct {
+	LocationType string `json:"locationType,omitempty"`
+	Location     string `json:"location,omitempty"`
+	Path         string `json:"path,omitempty"`
 }
 
 // ColumnMetadata describes a result column's type information.


### PR DESCRIPTION
Forward query request bindings from the gosnowflake-compatible endpoint to the query executor and normalize binding keys so placeholders generated by the Snowflake Go driver, such as :v1 and :v2, are properly substituted before SQL execution.